### PR TITLE
updated setup.py pyrodigal version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
         'six>=1.16.0',
         'pandas>=2.0.2 ',
         'biopython>=1.83',
-        'pyrodigal'
+        'pyrodigal>=3.0.0'
 
     ],
 


### PR DESCRIPTION
set a minimum version of pyrodigal as version 2 does not contain GeneFinder